### PR TITLE
Integrate Prometheus metrics into Operator

### DIFF
--- a/controllers/job.go
+++ b/controllers/job.go
@@ -28,7 +28,7 @@ import (
 )
 
 const (
-	workerImage   = "artilleryio/artillery:latest"
+	workerImage   = "ghcr.io/artilleryio/artillery-metrics-enabled:experimental"
 	testScriptVol = "test-script"
 )
 
@@ -95,6 +95,7 @@ func (r *LoadTestReconciler) job(v *lt.LoadTest) *v1.Job {
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: labels(v, "loadtest-worker"),
 				},
+
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
 						{
@@ -109,6 +110,16 @@ func (r *LoadTestReconciler) job(v *lt.LoadTest) *v1.Job {
 							Args: []string{
 								"run",
 								"/data/test-script.yaml",
+							},
+							Env: []corev1.EnvVar{
+								{
+									Name: "WORKER_ID",
+									ValueFrom: &corev1.EnvVarSource{
+										FieldRef: &corev1.ObjectFieldSelector{
+											FieldPath: "metadata.name",
+										},
+									},
+								},
 							},
 						},
 					},

--- a/hack/metrics/Dockerfile.metricsv2
+++ b/hack/metrics/Dockerfile.metricsv2
@@ -1,0 +1,14 @@
+FROM artilleryio/artillery:latest
+LABEL maintainer="team@artillery.io"
+
+RUN apk -U upgrade \
+  && apk add --no-cache git
+
+WORKDIR /home/node/artillery
+
+RUN npm \
+    install \
+    "https://github.com/artilleryio/artillery-plugin-publish-metrics.git#ezo/art-221-implement-pushgateway-integration-based" \
+    --save
+
+ENTRYPOINT ["/home/node/artillery/bin/artillery"]


### PR DESCRIPTION
This PR resolves: https://linear.app/artillery/issue/ART-223 and https://linear.app/artillery/issue/ART-224

## Updates

### Docker

- Adds a Dockerfile to help create an Artillery image with enabled Prometheus metrics publishing.
- Adds make targets to the Makefile to docker build and push artillery images with metrics enabled.

### Operator

- Use Artillery image with enabled Prometheus metrics for all Load Test Pods.

- Integrate with the metrics plugin using the `WORKER_ID` env var in worker Pods.
  That is, the Prometheus Pushgateway JobID corresponds to a Load Tests Pod name.

## Testing

- Ensured that created Load Tests can publish metrics as per test script plugin config.

- Ensured that stats are published correctly on The Prometheus Pushgateway with Job Ids corresponding to Load Test Pod names.