### PR TITLE
Clarify Prometheus and Pushgateway use in README

### DIFF
--- a/hack/examples/published-metrics-loadtest/test-script.yaml
+++ b/hack/examples/published-metrics-loadtest/test-script.yaml
@@ -16,7 +16,7 @@ config:
   plugins:
     publish-metrics:
       - type: prometheus
-        pushgateway: "http://host.docker.internal:9091"
+        pushgateway: "http://prometheus-pushgateway:9091"
         prefix: 'artillery_k8s'
         tags:
           - "load_test_id:test-378dbbbd-03eb-4d0e-8a66-39033a76d0f3"


### PR DESCRIPTION
Resolves https://linear.app/artillery/issue/ART-265

## Updates

- In the `published-metrics-loadtest` example, access the Pushgateway directly on K8s instead of forwarded localhost.
- Clarify how the `published-metrics-loadtest` example uses Prometheus and Pushgateway.
- Clarify the results of running the `hack/prom-pushgateway/up.sh` script.