### PR TITLE
Handle worker artillery cli errors

### DIFF
--- a/controllers/status.go
+++ b/controllers/status.go
@@ -112,9 +112,6 @@ func setConditions(v *lt.LoadTest, o ObservedStatus) {
 			LastTransitionTime: metav1.Now(),
 			LastProbeTime:      metav1.Now(),
 		}
-		if v.Status.Failed > 0 {
-			completed.Status = corev1.ConditionFalse
-		}
 		conditionsMap[lt.LoadTestCompleted] = completed
 	}
 

--- a/controllers/status.go
+++ b/controllers/status.go
@@ -180,7 +180,14 @@ func broadcastIfActiveOrCompleted(ctx context.Context, v *lt.LoadTest, r *LoadTe
 		telemeterActive(v, r, logger)
 
 	case o == LoadTestCompleted && v.Status.CompletionTime == nil:
-		r.Recorder.Event(v, "Normal", "Completed", "Load Test Completed")
+		msg := "Load Test completed"
+
+		if v.Status.Failed > 0 {
+			r.Recorder.Event(v, "Warning", "Failed", fmt.Sprintf("%s with failed workers", msg))
+		} else {
+			r.Recorder.Event(v, "Normal", "Completed", msg)
+		}
+
 		telemeterCompletion(v, r, logger)
 	}
 


### PR DESCRIPTION
This resolves https://linear.app/artillery/issue/ART-262

Load tests now complete regardless of the completion state of the underlying Job or underlying Job's workers.

## Updates

- A LoadTest completes when all workers succeed or fail or (succeed and fail).

- A warning event is now issued if a completed LoadTest has any failed workers.