### PR TITLE
Ezo/art 360 add telemetry to artillery kubectl

### DIFF
--- a/cmd/kubectl-artillery/main.go
+++ b/cmd/kubectl-artillery/main.go
@@ -13,16 +13,36 @@
 package main
 
 import (
+	"fmt"
+	"io"
 	"os"
 
 	"github.com/artilleryio/artillery-operator/commands"
+	"github.com/artilleryio/artillery-operator/controllers"
+	"github.com/artilleryio/artillery-operator/internal/telemetry"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 )
 
 func main() {
 	wd := "."
-	root := commands.NewCmdArtillery(wd, genericclioptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr})
+	ioStreams := genericclioptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr}
+
+	tCfg := telemetry.NewConfig(controllers.AppName, controllers.Version, controllers.WorkerImage, nil)
+	tClient, err := telemetry.NewClient(tCfg)
+	if err != nil {
+		_, _ = ioStreams.ErrOut.Write([]byte(fmt.Sprintf("unable to create telemetry client: %s", err.Error())))
+		os.Exit(1)
+	}
+	defer doClose(tClient, "could not close Posthog telemetry client", ioStreams)
+
+	root := commands.NewCmdArtillery(wd, ioStreams, tClient, tCfg)
 	if err := root.Execute(); err != nil {
 		os.Exit(1)
+	}
+}
+
+func doClose(closer io.Closer, msg string, ioStreams genericclioptions.IOStreams) {
+	if err := closer.Close(); err != nil {
+		_, _ = ioStreams.ErrOut.Write([]byte(fmt.Sprintf("%s: %s", msg, err.Error())))
 	}
 }

--- a/commands/artillery.go
+++ b/commands/artillery.go
@@ -63,7 +63,7 @@ func highlightTelemetryIfRequired(out io.Writer) error {
 		return nil
 	}
 
-	_, _ = out.Write([]byte("The kubectl artillery plugin uses telemetry\n"))
+	_, _ = out.Write([]byte("Telemetry is on. Learn more: https://artillery.io/docs/resources/core/telemetry.html\n"))
 
 	return settings.SetFirstRun(false).Save()
 }

--- a/commands/artillery.go
+++ b/commands/artillery.go
@@ -17,13 +17,20 @@ import (
 	"io"
 
 	"github.com/artilleryio/artillery-operator/internal/artillery"
+	"github.com/artilleryio/artillery-operator/internal/telemetry"
+	"github.com/posthog/posthog-go"
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 )
 
 const cliName = "kubectl artillery"
 
-func NewCmdArtillery(workingDir string, io genericclioptions.IOStreams) *cobra.Command {
+func NewCmdArtillery(
+	workingDir string,
+	io genericclioptions.IOStreams,
+	tClient posthog.Client,
+	tCfg telemetry.Config,
+) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Short:        "Use artillery.io operator helpers",
@@ -41,7 +48,7 @@ func NewCmdArtillery(workingDir string, io genericclioptions.IOStreams) *cobra.C
 		},
 	}
 
-	cmd.AddCommand(newCmdGenerate(workingDir, io, cliName))
+	cmd.AddCommand(newCmdGenerate(workingDir, io, cliName, tClient, tCfg))
 
 	return cmd
 }

--- a/controllers/job.go
+++ b/controllers/job.go
@@ -118,7 +118,7 @@ func (r *LoadTestReconciler) job(v *lt.LoadTest) *v1.Job {
 										},
 									},
 								},
-								r.TelemetryConfig.toEnvVar()...,
+								r.TelemetryConfig.ToEnvVar()...,
 							),
 						},
 					},

--- a/controllers/loadtest_controller.go
+++ b/controllers/loadtest_controller.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	lt "github.com/artilleryio/artillery-operator/api/v1alpha1"
+	"github.com/artilleryio/artillery-operator/internal/telemetry"
 	"github.com/posthog/posthog-go"
 	v1 "k8s.io/api/batch/v1"
 	core "k8s.io/api/core/v1"
@@ -33,7 +34,7 @@ type LoadTestReconciler struct {
 	client.Client
 	Scheme          *runtime.Scheme
 	Recorder        record.EventRecorder
-	TelemetryConfig TelemetryConfig
+	TelemetryConfig telemetry.Config
 	TelemetryClient posthog.Client
 }
 

--- a/controllers/settings.go
+++ b/controllers/settings.go
@@ -15,11 +15,9 @@ package controllers
 const (
 	AppName = "artillery-operator"
 
-	Version = "version"
+	Version = "alpha"
 
 	WorkerImage = "ghcr.io/artilleryio/artillery-metrics-enabled:v2.0.0"
 
 	TestScriptVol = "test-script"
-
-	PosthogToken = "_uzX-_WJoVmE_tsLvu0OFD2tpd0HGz72D5sU1zM2hbs"
 )

--- a/controllers/status.go
+++ b/controllers/status.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	lt "github.com/artilleryio/artillery-operator/api/v1alpha1"
+	"github.com/artilleryio/artillery-operator/internal/telemetry"
 	"github.com/go-logr/logr"
 	"github.com/thoas/go-funk"
 	v1 "k8s.io/api/batch/v1"
@@ -202,7 +203,7 @@ func broadcastIfActiveOrCompleted(ctx context.Context, v *lt.LoadTest, r *LoadTe
 		for _, pod := range podList.Items {
 			r.Recorder.Eventf(v, "Normal", "Running", "Running Load Test worker pod: %s", pod.Name)
 		}
-		telemeterActive(v, r, logger)
+		telemetry.TelemeterActive(v, r.TelemetryClient, r.TelemetryConfig, logger)
 
 	case o == LoadTestCompleted && v.Status.CompletionTime == nil:
 		msg := "Load Test completed"
@@ -213,7 +214,7 @@ func broadcastIfActiveOrCompleted(ctx context.Context, v *lt.LoadTest, r *LoadTe
 			r.Recorder.Event(v, "Normal", "Completed", msg)
 		}
 
-		telemeterCompletion(v, r, logger)
+		telemetry.TelemeterCompletion(v, r.TelemetryClient, r.TelemetryConfig, logger)
 	}
 
 	return nil

--- a/internal/artillery/iologger.go
+++ b/internal/artillery/iologger.go
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2022.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0.
+ *
+ * If a copy of the MPL was not distributed with
+ * this file, You can obtain one at
+ *
+ *   http://mozilla.org/MPL/2.0/
+ */
+
+package artillery
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/go-logr/logr"
+)
+
+func NewIOLogger(stdOut io.Writer, stdErr io.Writer) logr.Logger {
+	return &IOLogger{stdOut: stdOut, stdErr: stdErr, keysAndValues: []interface{}{}}
+}
+
+type IOLogger struct {
+	stdOut        io.Writer
+	stdErr        io.Writer
+	keysAndValues []interface{}
+}
+
+func (l *IOLogger) Enabled() bool                 { return true }
+func (l *IOLogger) V(_ int) logr.Logger           { return l }
+func (l *IOLogger) WithName(_ string) logr.Logger { return l }
+
+func (l *IOLogger) Info(msg string, keysAndValues ...interface{}) {
+	if len(l.keysAndValues) > 0 {
+		_, _ = l.stdOut.Write([]byte(fmt.Sprintf("%s %+v %+v\n", msg, l.keysAndValues, keysAndValues)))
+	} else {
+		_, _ = l.stdOut.Write([]byte(fmt.Sprintf("%s %+v\n", msg, keysAndValues)))
+	}
+}
+
+func (l *IOLogger) Error(err error, msg string, keysAndValues ...interface{}) {
+	if len(l.keysAndValues) > 0 {
+		_, _ = l.stdErr.Write([]byte(fmt.Sprintf("%s ... %s %+v %+v\n", err.Error(), msg, l.keysAndValues, keysAndValues)))
+	} else {
+		_, _ = l.stdErr.Write([]byte(fmt.Sprintf("%s ... %s %+v\n", err.Error(), msg, keysAndValues)))
+	}
+}
+
+func (l *IOLogger) WithValues(keysAndValues ...interface{}) logr.Logger {
+	l.keysAndValues = keysAndValues
+	return l
+}

--- a/internal/artillery/settings.go
+++ b/internal/artillery/settings.go
@@ -12,6 +12,77 @@
 
 package artillery
 
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
 const LoadTestFilename = "loadtest-cr.yaml"
 const LabelPrefix = "loadtest"
 const DefaultManifestDir = "artillery-manifests"
+const cliSettingsFilename = ".artillerykuberc"
+
+type CLISettings struct {
+	File      string                `yaml:"-" json:"-"`
+	Analytics *TelemetryCLISettings `yaml:"kubectl-artillery,omitempty" json:"kubectl-artillery,omitempty"`
+}
+
+type TelemetryCLISettings struct {
+	FirstRun *bool `yaml:"telemetry-first-run-msg,omitempty" json:"telemetry-first-run-msg,omitempty"`
+}
+
+func GetOrCreateCLISettings() (*CLISettings, error) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return nil, err
+	}
+
+	settingsPath := filepath.Join(homeDir, cliSettingsFilename)
+	if !DirOrFileExists(settingsPath) {
+		on := true
+		data, err := yaml.Marshal(&CLISettings{
+			Analytics: &TelemetryCLISettings{
+				FirstRun: &on,
+			},
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		if err := ioutil.WriteFile(settingsPath, data, 0666); err != nil {
+			return nil, err
+		}
+	}
+
+	var out CLISettings
+	data, err := ioutil.ReadFile(settingsPath)
+	if err != nil {
+		return nil, err
+	}
+	if err := yaml.Unmarshal(data, &out); err != nil {
+		return nil, err
+	}
+	out.File = settingsPath
+
+	return &out, nil
+}
+
+func (s *CLISettings) GetFirstRun() bool {
+	return *s.Analytics.FirstRun
+}
+
+func (s *CLISettings) SetFirstRun(b bool) *CLISettings {
+	s.Analytics.FirstRun = &b
+	return s
+}
+
+func (s *CLISettings) Save() error {
+	data, err := yaml.Marshal(s)
+	if err != nil {
+		return err
+	}
+	return ioutil.WriteFile(s.File, data, 0666)
+}

--- a/internal/telemetry/telemeter.go
+++ b/internal/telemetry/telemeter.go
@@ -72,3 +72,34 @@ func TelemeterCompletion(v *lt.LoadTest, tClient posthog.Client, tConfig Config,
 		)
 	}
 }
+
+func TelemeterGenerateManifests(
+	name, testScriptPath, env, outPath string,
+	count int,
+	tClient posthog.Client,
+	tConfig Config,
+	logger logr.Logger,
+) {
+	if err := enqueue(
+		tClient,
+		tConfig,
+		event{
+			Name: "operator kubectl-artillery generate",
+			Properties: map[string]interface{}{
+				"name":             hashEncode(name),
+				"testScript":       hashEncode(testScriptPath),
+				"count":            count,
+				"environment":      hashEncode(env),
+				"defaultOutputDir": len(outPath) == 0,
+			},
+		},
+		logger,
+	); err != nil {
+		logger.Error(err,
+			"could not broadcast telemetry",
+			"telemetry disable", tConfig.Disable,
+			"telemetry debug", tConfig.Debug,
+			"event", "operator kubectl-artillery generate",
+		)
+	}
+}

--- a/internal/telemetry/telemeter.go
+++ b/internal/telemetry/telemeter.go
@@ -86,6 +86,7 @@ func TelemeterGenerateManifests(
 		event{
 			Name: "operator kubectl-artillery generate",
 			Properties: map[string]interface{}{
+				"source":           "artillery-operator-kubectl-plugin",
 				"name":             hashEncode(name),
 				"testScript":       hashEncode(testScriptPath),
 				"count":            count,

--- a/internal/telemetry/telemeter.go
+++ b/internal/telemetry/telemeter.go
@@ -10,18 +10,19 @@
  *   http://mozilla.org/MPL/2.0/
  */
 
-package controllers
+package telemetry
 
 import (
 	lt "github.com/artilleryio/artillery-operator/api/v1alpha1"
 	"github.com/go-logr/logr"
+	"github.com/posthog/posthog-go"
 )
 
-func telemeterActive(v *lt.LoadTest, r *LoadTestReconciler, logger logr.Logger) {
-	if err := telemetryEnqueue(
-		r.TelemetryClient,
-		r.TelemetryConfig,
-		telemetryEvent{
+func TelemeterActive(v *lt.LoadTest, tClient posthog.Client, tConfig Config, logger logr.Logger) {
+	if err := enqueue(
+		tClient,
+		tConfig,
+		event{
 			Name: "operator test started",
 			Properties: map[string]interface{}{
 				"name":        hashEncode(v.Name),
@@ -35,20 +36,20 @@ func telemeterActive(v *lt.LoadTest, r *LoadTestReconciler, logger logr.Logger) 
 		logger.Error(err,
 			"could not broadcast telemetry",
 			"telemetry disable",
-			r.TelemetryConfig.Disable,
+			tConfig.Disable,
 			"telemetry debug",
-			r.TelemetryConfig.Debug,
+			tConfig.Debug,
 			"event",
 			"operator load test created",
 		)
 	}
 }
 
-func telemeterCompletion(v *lt.LoadTest, r *LoadTestReconciler, logger logr.Logger) {
-	err := telemetryEnqueue(
-		r.TelemetryClient,
-		r.TelemetryConfig,
-		telemetryEvent{
+func TelemeterCompletion(v *lt.LoadTest, tClient posthog.Client, tConfig Config, logger logr.Logger) {
+	err := enqueue(
+		tClient,
+		tConfig,
+		event{
 			Name: "operator test completed",
 			Properties: map[string]interface{}{
 				"name":        hashEncode(v.Name),
@@ -63,9 +64,9 @@ func telemeterCompletion(v *lt.LoadTest, r *LoadTestReconciler, logger logr.Logg
 		logger.Error(err,
 			"could not broadcast telemetry",
 			"telemetry disable",
-			r.TelemetryConfig.Disable,
+			tConfig.Disable,
 			"telemetry debug",
-			r.TelemetryConfig.Debug,
+			tConfig.Debug,
 			"event",
 			"operator load test completed",
 		)

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -168,13 +168,17 @@ func (t Config) ToEnvVar() []core.EnvVar {
 func getDisableConfig(logger logr.Logger) bool {
 	disable, ok := os.LookupEnv("ARTILLERY_DISABLE_TELEMETRY")
 	if !ok {
-		logger.Info("ARTILLERY_DISABLE_TELEMETRY was not set!")
+		if logger != nil {
+			logger.Info("ARTILLERY_DISABLE_TELEMETRY was not set!")
+		}
 		return false
 	}
 
 	parsedDisable, err := strconv.ParseBool(disable)
 	if err != nil {
-		logger.Info("ARTILLERY_DISABLE_TELEMETRY was not set with boolean type value. TELEMETRY REMAINS ENABLED")
+		if logger != nil {
+			logger.Info("ARTILLERY_DISABLE_TELEMETRY was not set with boolean type value. TELEMETRY REMAINS ENABLED")
+		}
 		return false
 	}
 
@@ -184,13 +188,17 @@ func getDisableConfig(logger logr.Logger) bool {
 func getDebugConfig(logger logr.Logger) bool {
 	debug, ok := os.LookupEnv("ARTILLERY_TELEMETRY_DEBUG")
 	if !ok {
-		logger.Info("ARTILLERY_TELEMETRY_DEBUG was not set!")
+		if logger != nil {
+			logger.Info("ARTILLERY_TELEMETRY_DEBUG was not set!")
+		}
 		return false
 	}
 
 	parsedDebug, err := strconv.ParseBool(debug)
 	if err != nil {
-		logger.Info("ARTILLERY_TELEMETRY_DEBUG was not set with boolean type value. TELEMETRY DEBUG REMAINS DISABLED")
+		if logger != nil {
+			logger.Info("ARTILLERY_TELEMETRY_DEBUG was not set with boolean type value. TELEMETRY DEBUG REMAINS DISABLED")
+		}
 		return false
 	}
 

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -10,7 +10,7 @@
  *   http://mozilla.org/MPL/2.0/
  */
 
-package controllers
+package telemetry
 
 import (
 	"crypto/sha1"
@@ -27,13 +27,15 @@ import (
 	core "k8s.io/api/core/v1"
 )
 
-type telemetryEvent struct {
+const PostHogToken = "_uzX-_WJoVmE_tsLvu0OFD2tpd0HGz72D5sU1zM2hbs"
+
+type event struct {
 	Name       string
 	Properties map[string]interface{}
 }
 
-func protectedDistinctId() (string, error) {
-	return machineid.ProtectedID(AppName)
+func protectedDistinctId(cfg Config) (string, error) {
+	return machineid.ProtectedID(cfg.AppName)
 }
 
 func hashEncode(v string) string {
@@ -65,21 +67,21 @@ func (n *noopClient) IsFeatureEnabled(_ string, _ string, _ bool) (bool, error) 
 func (n *noopClient) ReloadFeatureFlags() error                                 { return nil }
 func (n *noopClient) GetFeatureFlags() ([]posthog.FeatureFlag, error)           { return nil, nil }
 
-func NewTelemetryClient(tCfg TelemetryConfig) (posthog.Client, error) {
+func NewClient(tCfg Config) (posthog.Client, error) {
 	if tCfg.Disable {
 		return &noopClient{}, nil
 	}
-	return posthog.NewWithConfig(PosthogToken, posthog.Config{})
+	return posthog.NewWithConfig(PostHogToken, posthog.Config{})
 }
 
-func telemetryEnqueue(client posthog.Client, config TelemetryConfig, event telemetryEvent, logger logr.Logger) error {
-	properties := buildProperties(event.Properties)
+func enqueue(client posthog.Client, config Config, event event, logger logr.Logger) error {
+	properties := buildProperties(event.Properties, config)
 	if config.Debug {
-		debugTelemetryProperties(properties, logger)
+		debugProperties(properties, logger)
 		return nil
 	}
 
-	distinctId, err := protectedDistinctId()
+	distinctId, err := protectedDistinctId(config)
 	if err != nil {
 		return err
 	}
@@ -95,23 +97,23 @@ func telemetryEnqueue(client posthog.Client, config TelemetryConfig, event telem
 	return nil
 }
 
-func debugTelemetryProperties(props map[string]interface{}, logger logr.Logger) {
+func debugProperties(props map[string]interface{}, logger logr.Logger) {
 	for k, v := range props {
 		logger.Info("ARTILLERY_TELEMETRY_DEBUG=true", k, v)
 	}
 }
 
-func buildProperties(extra map[string]interface{}) map[string]interface{} {
+func buildProperties(extra map[string]interface{}, cfg Config) map[string]interface{} {
 	hostname, err := os.Hostname()
 	if err != nil {
 		hostname = ""
 	}
 
 	properties := map[string]interface{}{
-		"source":       AppName,
-		"version":      Version,
+		"source":       cfg.AppName,
+		"version":      cfg.Version,
 		"containerOS":  strings.ToLower(runtime.GOOS),
-		"workerImage":  WorkerImage,
+		"workerImage":  cfg.WorkerImage,
 		"ipHash":       hashEncode(getIPAddress()),
 		"hostnameHash": hashEncode(hostname),
 		"$ip":          nil,
@@ -124,26 +126,33 @@ func buildProperties(extra map[string]interface{}) map[string]interface{} {
 	return properties
 }
 
-type TelemetryConfig struct {
-	Disable bool
-	Debug   bool
+type Config struct {
+	Disable     bool
+	Debug       bool
+	AppName     string
+	Version     string
+	WorkerImage string
 }
 
-func NewTelemetryConfig(logger logr.Logger) TelemetryConfig {
-	result := TelemetryConfig{}
+func NewConfig(appName, version, workerImage string, logger logr.Logger) Config {
+	result := Config{
+		AppName:     appName,
+		Version:     version,
+		WorkerImage: workerImage,
+	}
 
-	if getTelemetryDisableConfig(logger) {
+	if getDisableConfig(logger) {
 		result.Disable = true
 	}
 
-	if getTelemetryDebugConfig(logger) {
+	if getDebugConfig(logger) {
 		result.Debug = true
 	}
 
 	return result
 }
 
-func (t TelemetryConfig) toEnvVar() []core.EnvVar {
+func (t Config) ToEnvVar() []core.EnvVar {
 	return []core.EnvVar{
 		{
 			Name:  "ARTILLERY_DISABLE_TELEMETRY",
@@ -156,7 +165,7 @@ func (t TelemetryConfig) toEnvVar() []core.EnvVar {
 	}
 }
 
-func getTelemetryDisableConfig(logger logr.Logger) bool {
+func getDisableConfig(logger logr.Logger) bool {
 	disable, ok := os.LookupEnv("ARTILLERY_DISABLE_TELEMETRY")
 	if !ok {
 		logger.Info("ARTILLERY_DISABLE_TELEMETRY was not set!")
@@ -172,7 +181,7 @@ func getTelemetryDisableConfig(logger logr.Logger) bool {
 	return parsedDisable
 }
 
-func getTelemetryDebugConfig(logger logr.Logger) bool {
+func getDebugConfig(logger logr.Logger) bool {
 	debug, ok := os.LookupEnv("ARTILLERY_TELEMETRY_DEBUG")
 	if !ok {
 		logger.Info("ARTILLERY_TELEMETRY_DEBUG was not set!")

--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ import (
 	"io"
 	"os"
 
+	"github.com/artilleryio/artillery-operator/internal/telemetry"
 	"github.com/go-logr/logr"
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
@@ -88,8 +89,8 @@ func main() {
 		Recorder: mgr.GetEventRecorderFor("loadtest-controller"),
 	}
 
-	telemetryConfig := controllers.NewTelemetryConfig(setupLog)
-	telemetryClient, err := controllers.NewTelemetryClient(telemetryConfig)
+	telemetryConfig := telemetry.NewConfig(controllers.AppName, controllers.Version, controllers.WorkerImage, setupLog)
+	telemetryClient, err := telemetry.NewClient(telemetryConfig)
 	if err != nil {
 		setupLog.Error(err, "unable to create telemetry client")
 		os.Exit(1)


### PR DESCRIPTION
Resolves: https://linear.app/artillery/issue/ART-360

## Updates

- Refactors telemetry into its own internal package for better reuse between controller and kubectl plugin.
- Adds telemetry to kubectl artillery `generate` commands.
- Highlights telemetry use on first plugin run.
