### PR TITLE
Distribute artillery kubectl plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,7 @@ artillery-manifests/
 *.swp
 *.swo
 *~
+
+# Distribution
+dist/
+*.goreleaser-github-token

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,86 @@
+# This is an example .goreleaser.yml file with some sensible defaults.
+# Make sure to check the documentation at https://goreleaser.com
+project_name: kubectl-artillery
+release:
+  # If set to true, will not auto-publish the release.
+  # Default is false.
+  draft: true
+env_files:
+  github_token: .goreleaser-github-token
+before:
+  hooks:
+    # You may remove this if you don't use go modules.
+    - go mod tidy
+    - go mod download
+builds:
+  # You can have multiple builds defined as a yaml list
+  - # ID of the build.
+    # Defaults to the project name.
+    id: "kubectl-artillery"
+
+    # Path to main.go file or main package.
+    # Notice: when used with `gomod.proxy`, this must be a package.
+    #
+    # Default is `.`.
+    main: ./cmd/kubectl-artillery
+
+    # Binary name.
+    # Can be a path (e.g. `bin/app`) to wrap the binary in a directory.
+    # Default is the name of the project directory.
+    binary: kubectl-artillery
+
+    env:
+      - CGO_ENABLED=0
+
+    # GOOS list to build for.
+    # For more info refer to: https://golang.org/doc/install/source#environment
+    # Defaults are darwin and linux.
+    goos:
+      - linux
+      - windows
+      - darwin
+
+    # GOARCH to build for.
+    # For more info refer to: https://golang.org/doc/install/source#environment
+    # Defaults are 386, amd64 and arm64.
+    goarch:
+      - amd64
+      - arm
+      - arm64
+archives:
+  - # ID of this archive.
+    # Defaults to `default`.
+    id: "kubectl-artillery"
+
+    # Archive name template.
+    # Defaults:
+    # - if format is `tar.gz`, `tar.xz`, `gz` or `zip`:
+    #   - `{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}`
+    # - if format is `binary`:
+    #   - `{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}`
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}_{{ .Date }}"
+
+    # Can be used to change the archive formats for specific GOOSs.
+    # Most common use case is to archive as zip on Windows.
+    # Default is empty.
+    format_overrides:
+      - goos: windows
+        format: zip
+    # Additional files/template/globs you want to add to the archive.
+    # Defaults are any files matching `LICENSE*`, `README*`, `CHANGELOG*`,
+    #  `license*`, `readme*` and `changelog*`.
+    files:
+      - LICENSE.txt
+    wrap_in_directory: "true"
+gomod:
+  proxy: true
+checksum:
+  name_template: 'checksums.txt'
+snapshot:
+  name_template: "{{ incpatch .Version }}-next"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'


### PR DESCRIPTION
Resolves https://linear.app/artillery/issue/ART-358

## Updates

- Adds a `.goreleaser.yaml` config to publish `kubectl-artillery` draft releases to GitHub (using [goreleaser](https://goreleaser.com)).
- Adds a Makefile `kubeplugin-release` task to kickoff plugin release.
- The `kubeplugin-release` installs `goreleaser` under the `./bin` directory, if its not already installed.