### PR TITLE
Update scripts: Force bash & Handle go 1.18 go get deprecation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,32 +152,35 @@ telemetry-deploy: deploy
 undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config.
 	$(KUSTOMIZE) build config/default | kubectl delete -f -
 
+## Location to install dependencies to
+LOCALBIN ?= $(shell pwd)/bin
+$(LOCALBIN): ## Ensure that the directory exists
+	mkdir -p $(LOCALBIN)
 
-CONTROLLER_GEN = $(shell pwd)/bin/controller-gen
-controller-gen: ## Download controller-gen locally if necessary.
-	$(call go-get-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.7.0)
+## Tool Binaries
+KUSTOMIZE ?= $(LOCALBIN)/kustomize
+CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
+ENVTEST ?= $(LOCALBIN)/setup-envtest
 
-KUSTOMIZE = $(shell pwd)/bin/kustomize
-kustomize: ## Download kustomize locally if necessary.
-	$(call go-get-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v3@v3.8.7)
+## Tool Versions
+KUSTOMIZE_VERSION ?= v3.8.7
+CONTROLLER_TOOLS_VERSION ?= v0.8.0
 
-ENVTEST = $(shell pwd)/bin/setup-envtest
-envtest: ## Download envtest-setup locally if necessary.
-	$(call go-get-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest@latest)
+KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"
+.PHONY: kustomize
+kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
+$(KUSTOMIZE):
+	curl -s $(KUSTOMIZE_INSTALL_SCRIPT) | bash -s -- $(subst v,,$(KUSTOMIZE_VERSION)) $(LOCALBIN)
 
-# go-get-tool will 'go get' any package $2 and install it to $1.
-PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
-define go-get-tool
-@[ -f $(1) ] || { \
-set -e ;\
-TMP_DIR=$$(mktemp -d) ;\
-cd $$TMP_DIR ;\
-go mod init tmp ;\
-echo "Downloading $(2)" ;\
-GOBIN=$(PROJECT_DIR)/bin go get $(2) ;\
-rm -rf $$TMP_DIR ;\
-}
-endef
+.PHONY: controller-gen
+controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessary.
+$(CONTROLLER_GEN):
+	GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-tools/cmd/controller-gen@$(CONTROLLER_TOOLS_VERSION)
+
+.PHONY: envtest
+envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
+$(ENVTEST):
+	GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
 
 define go-get-install
 @[ -f $(1) ] || { \

--- a/Makefile
+++ b/Makefile
@@ -182,18 +182,6 @@ envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
 $(ENVTEST):
 	GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
 
-define go-get-install
-@[ -f $(1) ] || { \
-set -e ;\
-TMP_DIR=$$(mktemp -d) ;\
-cd $$TMP_DIR ;\
-go mod init tmp ;\
-echo "Downloading $(2)" ;\
-GOBIN=$(PROJECT_DIR)/bin go install $(2) ;\
-rm -rf $$TMP_DIR ;\
-}
-endef
-
 .PHONY: bundle
 bundle: manifests kustomize ## Generate bundle manifests and metadata, then validate generated files.
 	operator-sdk generate kustomize manifests -q
@@ -259,9 +247,9 @@ catalog-push: ## Push a catalog image.
 # ** ENSURE the repo is NOT in a dirty state before running the task.
 .PHONY: goreleaser kubeplugin-release, check-release-tag-version, check-release-tag-msg
 
-GORELEASER = $(shell pwd)/bin/goreleaser
+GORELEASER ?= $(LOCALBIN)/goreleaser
 goreleaser: ## Download goreleaser locally if necessary.
-	$(call go-get-install,$(GORELEASER),github.com/goreleaser/goreleaser@latest)
+	GOBIN=$(LOCALBIN) go install github.com/goreleaser/goreleaser@latest
 
 check-release-tag-version:
 ifndef KUBEPLUGIN_TAG_VERSION

--- a/hack/kind/kind-with-registry.sh
+++ b/hack/kind/kind-with-registry.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -o errexit
 
 # full directory name of the script no matter where it is being called from

--- a/hack/kind/kind-with-registry.sh
+++ b/hack/kind/kind-with-registry.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -o errexit
+set -o posix
 
 # full directory name of the script no matter where it is being called from
 script_dir="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"

--- a/hack/prom-pushgateway/down.sh
+++ b/hack/prom-pushgateway/down.sh
@@ -12,6 +12,7 @@
 #
 
 set -o errexit
+set -o posix
 
 # full directory name of the script no matter where it is being called from
 # shellcheck disable=SC2039

--- a/hack/prom-pushgateway/down.sh
+++ b/hack/prom-pushgateway/down.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Copyright (c) 2022.
 #

--- a/hack/prom-pushgateway/up.sh
+++ b/hack/prom-pushgateway/up.sh
@@ -12,6 +12,7 @@
 #
 
 set -o errexit
+set -o posix
 
 # full directory name of the script no matter where it is being called from
 # shellcheck disable=SC2039

--- a/hack/prom-pushgateway/up.sh
+++ b/hack/prom-pushgateway/up.sh
@@ -34,7 +34,7 @@ if [ ! -f "${kube_prom_zip}" ]; then
 fi
 
 # unpack the operator
-tar -zxvf "${kube_prom_zip}" -C "${script_dir}"
+unzip "${kube_prom_zip}" -d "${script_dir}"
 
 # source: https://prometheus-operator.dev/docs/prologue/quick-start/
 # create the monitoring stack

--- a/hack/prom-pushgateway/up.sh
+++ b/hack/prom-pushgateway/up.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Copyright (c) 2022.
 #

--- a/operator-deploy.sh
+++ b/operator-deploy.sh
@@ -12,6 +12,7 @@
 #
 
 set -o errexit
+set -o posix
 
 source ./scripts/deploy-helpers.sh
 

--- a/operator-deploy.sh
+++ b/operator-deploy.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Copyright (c) 2022.
 #

--- a/operator-undeploy.sh
+++ b/operator-undeploy.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -o errexit
+set -o posix
 
 source ./scripts/deploy-helpers.sh
 

--- a/operator-undeploy.sh
+++ b/operator-undeploy.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -o errexit
 
 source ./scripts/deploy-helpers.sh


### PR DESCRIPTION
This pr:
Handles deprecation of go get (based on this [kubebuilder pr](https://github.com/kubernetes-sigs/kubebuilder/pull/2486))
Handles cases where bash is not the default non-interactive shell (e.g., Debian).

Note:
Swapping 'source' for '.' and revisiting [line 5](https://github.com/juanig1/artillery-operator/blob/a8b92de72c081feb34d156ef799f69354d6e712e/hack/kind/kind-with-registry.sh#L5) of hack/kind/kind-with-registry.sh (bad substitution error) may be an option if we want to keep using /bin/sh.


