### PR TITLE
Validate test-scripts config is available to a Load Test

### DIFF
--- a/api/v1alpha1/loadtest_types.go
+++ b/api/v1alpha1/loadtest_types.go
@@ -42,11 +42,14 @@ type External struct {
 }
 
 type Config struct {
-	ConfigMap string `json:"configMap,omitempty"`
+	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:Required
+	ConfigMap string `json:"configMap"`
 }
 
 type TestScript struct {
-	Config   Config    `json:"config,omitempty"`
+	// +kubebuilder:validation:Required
+	Config   Config    `json:"config"`
 	External *External `json:"external,omitempty"`
 }
 
@@ -55,9 +58,11 @@ type LoadTestSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
-	Count       int        `json:"count,omitempty"`
-	Environment string     `json:"environment,omitempty"`
-	TestScript  TestScript `json:"testScript,omitempty"`
+	Count       int    `json:"count,omitempty"`
+	Environment string `json:"environment,omitempty"`
+
+	// +kubebuilder:validation:Required
+	TestScript TestScript `json:"testScript"`
 }
 
 type LoadTestConditionType string

--- a/config/crd/bases/loadtest.artillery.io_loadtests.yaml
+++ b/config/crd/bases/loadtest.artillery.io_loadtests.yaml
@@ -62,7 +62,10 @@ spec:
                   config:
                     properties:
                       configMap:
+                        minLength: 1
                         type: string
+                    required:
+                    - configMap
                     type: object
                   external:
                     properties:
@@ -89,7 +92,11 @@ spec:
                             type: object
                         type: object
                     type: object
+                required:
+                - config
                 type: object
+            required:
+            - testScript
             type: object
           status:
             description: LoadTestStatus defines the observed state of LoadTest

--- a/controllers/loadtest_controller.go
+++ b/controllers/loadtest_controller.go
@@ -18,13 +18,11 @@ import (
 
 	lt "github.com/artilleryio/artillery-operator/api/v1alpha1"
 	"github.com/artilleryio/artillery-operator/internal/telemetry"
-	"github.com/go-logr/logr"
 	"github.com/posthog/posthog-go"
 	v1 "k8s.io/api/batch/v1"
 	core "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -111,29 +109,4 @@ func (r *LoadTestReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&v1.Job{}).
 		Owns(&core.Pod{}).
 		Complete(r)
-}
-
-func (r *LoadTestReconciler) ensureTestScriptConfig(ctx context.Context,
-	instance *lt.LoadTest,
-	logger logr.Logger) (*ctrl.Result, error) {
-	configMap := instance.Spec.TestScript.Config.ConfigMap
-
-	found := &core.ConfigMap{}
-	err := r.Get(ctx, types.NamespacedName{
-		Name:      configMap,
-		Namespace: instance.Namespace,
-	}, found)
-
-	if err != nil && errors.IsNotFound(err) {
-		logger.Error(err, "TestScript ConfigMap is missing", "Testscript.Config.ConfigMap", configMap)
-		r.Recorder.Eventf(instance, "Warning", "MissingTestScript", "Cannot locate the Test Script ConfigMap: %s", configMap)
-
-		return &ctrl.Result{}, err
-	} else if err != nil {
-		logger.Error(err, "Failed to get ConfigMap", "Testscript.Config.ConfigMap", configMap)
-		return &ctrl.Result{}, err
-	}
-
-	// ConfigMap located
-	return nil, nil
 }

--- a/controllers/loadtest_controller.go
+++ b/controllers/loadtest_controller.go
@@ -18,11 +18,13 @@ import (
 
 	lt "github.com/artilleryio/artillery-operator/api/v1alpha1"
 	"github.com/artilleryio/artillery-operator/internal/telemetry"
+	"github.com/go-logr/logr"
 	"github.com/posthog/posthog-go"
 	v1 "k8s.io/api/batch/v1"
 	core "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -76,6 +78,11 @@ func (r *LoadTestReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		return ctrl.Result{}, err
 	}
 
+	result, err = r.ensureTestScriptConfig(ctx, loadTest, logger)
+	if result != nil {
+		return *result, err
+	}
+
 	result, err = r.ensureJob(ctx, loadTest, logger, r.job(loadTest))
 	if result != nil {
 		return *result, err
@@ -104,4 +111,29 @@ func (r *LoadTestReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&v1.Job{}).
 		Owns(&core.Pod{}).
 		Complete(r)
+}
+
+func (r *LoadTestReconciler) ensureTestScriptConfig(ctx context.Context,
+	instance *lt.LoadTest,
+	logger logr.Logger) (*ctrl.Result, error) {
+	configMap := instance.Spec.TestScript.Config.ConfigMap
+
+	found := &core.ConfigMap{}
+	err := r.Get(ctx, types.NamespacedName{
+		Name:      configMap,
+		Namespace: instance.Namespace,
+	}, found)
+
+	if err != nil && errors.IsNotFound(err) {
+		logger.Error(err, "TestScript ConfigMap is missing", "Testscript.Config.ConfigMap", configMap)
+		r.Recorder.Eventf(instance, "Warning", "MissingTestScript", "Cannot locate the Test Script ConfigMap: %s", configMap)
+
+		return &ctrl.Result{}, err
+	} else if err != nil {
+		logger.Error(err, "Failed to get ConfigMap", "Testscript.Config.ConfigMap", configMap)
+		return &ctrl.Result{}, err
+	}
+
+	// ConfigMap located
+	return nil, nil
 }

--- a/controllers/testscript.go
+++ b/controllers/testscript.go
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2022.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0.
+ *
+ * If a copy of the MPL was not distributed with
+ * this file, You can obtain one at
+ *
+ *   http://mozilla.org/MPL/2.0/
+ */
+
+package controllers
+
+import (
+	"context"
+
+	lt "github.com/artilleryio/artillery-operator/api/v1alpha1"
+	"github.com/go-logr/logr"
+	core "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+func (r *LoadTestReconciler) ensureTestScriptConfig(ctx context.Context,
+	instance *lt.LoadTest,
+	logger logr.Logger) (*ctrl.Result, error) {
+	configMap := instance.Spec.TestScript.Config.ConfigMap
+
+	found := &core.ConfigMap{}
+	err := r.Get(ctx, types.NamespacedName{
+		Name:      configMap,
+		Namespace: instance.Namespace,
+	}, found)
+
+	if err != nil && errors.IsNotFound(err) {
+		logger.Error(err, "TestScript ConfigMap is missing", "Testscript.Config.ConfigMap", configMap)
+		r.Recorder.Eventf(instance, "Warning", "MissingTestScript", "Load Test test script ConfigMap is missing, see field .spec.testScript.config.configMap")
+
+		return &ctrl.Result{}, err
+	} else if err != nil {
+		logger.Error(err, "Failed to get ConfigMap", "Testscript.Config.ConfigMap", configMap)
+		return &ctrl.Result{}, err
+	}
+
+	// ConfigMap located
+	return nil, nil
+}


### PR DESCRIPTION
This resolves: https://linear.app/artillery/issue/ART-146

## Update

- Adds CRD marker validation for test script related fields.
- Stops the controller from running a LoadTest until a test script ConfigMap is available.
- Fires `warning` events when a test script config map is missing.