### PR TITLE
Operator workers should add telemetry context to workers

### DIFF
--- a/controllers/job.go
+++ b/controllers/job.go
@@ -94,8 +94,9 @@ func (r *LoadTestReconciler) job(v *lt.LoadTest) *v1.Job {
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
 						{
-							Name:  v.Name,
-							Image: WorkerImage,
+							Name:            v.Name,
+							Image:           WorkerImage,
+							ImagePullPolicy: corev1.PullAlways,
 							VolumeMounts: []corev1.VolumeMount{
 								{
 									Name:      TestScriptVol,

--- a/controllers/job.go
+++ b/controllers/job.go
@@ -109,6 +109,8 @@ func (r *LoadTestReconciler) job(v *lt.LoadTest) *v1.Job {
 							Env: append(
 								[]corev1.EnvVar{
 									// published metrics use WORKER_ID to connect the pod (worker) to a Pushgateway JobID
+									// Uses the downward API:
+									// https://kubernetes.io/docs/tasks/inject-data-application/downward-api-volume-expose-pod-information/#the-downward-api
 									{
 										Name: "WORKER_ID",
 										ValueFrom: &corev1.EnvVarSource{

--- a/controllers/settings.go
+++ b/controllers/settings.go
@@ -17,7 +17,7 @@ const (
 
 	Version = "alpha"
 
-	WorkerImage = "ghcr.io/artilleryio/artillery-metrics-enabled:v2.0.0"
+	WorkerImage = "artilleryio/artillery:latest"
 
 	TestScriptVol = "test-script"
 )

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -15,6 +15,7 @@ package telemetry
 import (
 	"crypto/sha1"
 	"encoding/base64"
+	"fmt"
 	"net"
 	"os"
 	"runtime"
@@ -161,6 +162,12 @@ func (t Config) ToEnvVar() []core.EnvVar {
 		{
 			Name:  "ARTILLERY_TELEMETRY_DEBUG",
 			Value: strconv.FormatBool(t.Debug),
+		},
+		// This a serialised JSON object that will be propagated
+		// on every worker event
+		{
+			Name:  "ARTILLERY_TELEMETRY_DEFAULTS",
+			Value: fmt.Sprintf(`{"testRunner": "%s"}`, t.AppName),
 		},
 	}
 }


### PR DESCRIPTION
This resolves: https://linear.app/artillery/issue/ART-403

## Updates

- `testRunner` added to worker telemetry using `ARTILLERY_TELEMETRY_DEFAULTS` env var.
- Workers now use the latest artillery image to make artillery updates always available to the operator.
- General tidy up.
